### PR TITLE
Bump Base Image from 12.1.0 to 12.6.0 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an NVIDIA CUDA image as the base
-FROM nvidia/cuda:12.1.0-devel-ubuntu20.04
+FROM nvidia/cuda:12.6.0-devel-ubuntu20.04
 
 # Set up environment variables
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
While testing I reciveed a deprecation notice. This bumps to the latest similar Ubuntu version to 12.6.0 https://hub.docker.com/r/nvidia/cuda/tags?page=&page_size=&ordering=&name=12.6.0-devel-ubuntu20.04

```
==========
== CUDA ==
==========

CUDA Version 12.1.0

Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

This container image and its contents are governed by the NVIDIA Deep Learning Container License.
By pulling and using the container, you accept the terms and conditions of this license:
https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.

*************************
** DEPRECATION NOTICE! **
*************************
THIS IMAGE IS DEPRECATED and is scheduled for DELETION.
    https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/support-policy.md

To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.
```