### PR TITLE
ROS integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an NVIDIA CUDA image as the base
-FROM nvidia/cuda:12.6.0-devel-ubuntu20.04
+FROM nvidia/cuda:12.2.0-devel-ubuntu20.04
 
 # Set up environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -85,6 +85,33 @@ RUN sudo apt-get install -y python3-pip
 RUN python3 -m pip install PyGObject --force-reinstall
 RUN pip3 install pycryptodome
 RUN sudo apt install -y ros-noetic-desktop-full
+
+# Install Open3D system dependencies and pip
+# RUN apt-get update && apt-get install --no-install-recommends -y \
+#     libgl1 \
+#     libgomp1 \
+#     python3-pip \
+#     && sudo rm -rf /var/lib/apt/lists/*
+
+# Install Open3D from the pypi repositories
+# RUN python3 -m pip install --no-cache-dir --upgrade open3d
+
+RUN sudo echo "export PYTHONPATH="${PYTHONPATH}:/home/user/segment-anything-2"" >> ~/.bashrc
+RUN python3 -m pip install av && python3 -m pip install pynput
+# RUN python3.8 -m pip install cmake --upgrade
+# RUN cd /usr/bin && sudo rm cmake 
+# RUN sudo ln /home/user/.local/bin/cmake /usr/bin/cmake
+# RUN git clone https://github.com/isl-org/Open3D
+# RUN cd Open3D \
+#     && echo y | util/install_deps_ubuntu.sh \
+#     && mkdir build && cd build \
+#     && cmake .. \ 
+#     && make -j$(nproc) \
+#     && sudo make install \
+#     && sudo make install-pip-package 
+
+RUN python3.8 -m pip install --upgrade pip
+RUN python3.8 -m pip install open3d==0.18.0
 
 STOPSIGNAL SIGTERM
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 👀 Segment Anything 2 + ROS Noetic <img src="https://github.com/user-attachments/assets/ff47e547-4b5c-4477-9d10-09dfce2aed27" width="48"> + Docker  🐳
+# 👀 Segment Anything 2 + ROS Noetic <img src="https://github.com/user-attachments/assets/fe401509-2e0a-422a-8f6b-242a1c9559a8" width="48"> + Docker  🐳
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,26 @@
-# 👀 Segment Anything 2 + Docker  🐳
-
-![image](https://github.com/user-attachments/assets/7911d7b8-72a7-4c90-9da6-7a867b0136f8)
-
-
-Segment Anything in Docker. A simple, easy to use Docker image for Meta's SAM2 with GUI support for displaying figures. Built on top of the SAM2 repo: https://github.com/facebookresearch/segment-anything-2
-
+# 👀 Segment Anything 2 + ROS Noetic ![image](https://github.com/user-attachments/assets/973b4fa5-915d-4d49-8ac0-e24b408b0af8) + Docker  🐳
 
 ## Quickstart
 
-This quickstart assumes you have access to an NVIDIA GPU. You should have installed the NVIDIA drivers and CUDA toolkit for your GPU beforehand. Also, make to install Docker [here](https://docs.docker.com/engine/install/).
-
-First, let's install the NVIDIA Container Toolkit:
-
+Read instructions on the main branch first. To use with ROS, run:
 ```bash
-distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
-   && curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add - \
-   && curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-sudo apt-get update
-sudo apt-get install -y nvidia-docker2
-sudo systemctl restart docker
+docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY --gpus all sam2-ros-docker bash
+```
+Inside the container, run
+```bash
+source ~/.bashrc
+gnome-terminal
 ```
 
-To get the SAM2 Docker image up and running, you can run:
+## Connecting to ROS running on the local host
 
+Run `roscore` in both machines to find the port being used. Then close the container and rerun with the `-p` flag: 
 ```bash
-sudo usermod -aG docker $USER
-newgrp docker
-docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix  -e DISPLAY=$DISPLAY --gpus all peasant98/sam2:latest bash
+docker run -it -p [HOST_PORT]:[CONTAINER_PORT] -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=$DISPLAY --gpus all sam2-ros-docker bash
 ```
 
-From this shell, you can run SAM2, as well as display plots and images.
-
-## Building and Running Locally
-
-To build and run the Dockerfile:
-
-```bash
-docker build -t sam2:latest . 
+To test, run `roscore` in the docker container and `rostopic list` on the local host. The local host should show
 ```
-
-And you can run as:
-
-```bash
-docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix  -e DISPLAY=$DISPLAY --gpus all sam2:latest bash
+/rosout
+/rosout_agg
 ```
-
-
-Example of running Python code to display masks:
-
-![alt text](image.png)
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 👀 Segment Anything 2 + ROS Noetic <img src="https://github.com/user-attachments/assets/fe401509-2e0a-422a-8f6b-242a1c9559a8" width="48"> + Docker  🐳
+# 👀 Segment Anything 2 + <img src="https://github.com/user-attachments/assets/fe401509-2e0a-422a-8f6b-242a1c9559a8" width="45"> ROS Noetic + Docker  🐳
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# 👀 Segment Anything 2 + ROS Noetic ![image](https://github.com/user-attachments/assets/973b4fa5-915d-4d49-8ac0-e24b408b0af8) + Docker  🐳
+# 👀 Segment Anything 2 + ROS Noetic ![image](https://github.com/user-attachments/assets/ff47e547-4b5c-4477-9d10-09dfce2aed27)
+ + Docker  🐳
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# 👀 Segment Anything 2 + ROS Noetic ![image](https://github.com/user-attachments/assets/ff47e547-4b5c-4477-9d10-09dfce2aed27)
- + Docker  🐳
+# 👀 Segment Anything 2 + ROS Noetic <img src="https://github.com/user-attachments/assets/ff47e547-4b5c-4477-9d10-09dfce2aed27" width="48"> + Docker  🐳
 
 ## Quickstart
 


### PR DESCRIPTION
This docker includes a base ROS Noetic installation in addition to the existing SAM2 installation and associated packages.

It comes with gnome-terminal since working with ROS often involves using multiple terminals.

- ROS doesn't work with Python3.11, so Python3.8 is default
- Noetic installation done twice because some utils disappear (not ideal)
- If building locally with CUDA <12.6, one may need to change version in top line of Dockerfile or `cd /etc/nvidia-container-runtime/config.toml` and set `disable-require = true` (consider mentioning in main README?)